### PR TITLE
Use uvx for dev tools instead of installing as dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,23 @@ repos:
         args:
           - --fix
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+  - repo: local
     hooks:
       - id: ruff
-        args: [ --fix ]
+        name: ruff
+        entry: uvx ruff check --fix
+        language: system
+        types: [python]
+        pass_filenames: true
       - id: ruff-format
-
-  - repo: https://github.com/allganize/ty-pre-commit
-    rev: v0.0.19
-    hooks:
-      - id: ty-check
+        name: ruff-format
+        entry: uvx ruff format
+        language: system
+        types: [python]
+        pass_filenames: true
+      - id: ty
+        name: ty
+        entry: uvx ty check
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ This will create a virtual environment and install needed development dependenci
 
 ## Pre-commit hooks
 
-Install the pre-commit hooks (`pre-commit` has been installed by `uv`)
+Install the pre-commit hooks:
 
 ```sh
-uv run pre-commit install
+uvx pre-commit install
 ```
 
 This will create a `.git/hooks/pre-commit` file that will run the pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "Base python project"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "pre-commit>=4.2.0",
-    "ty>=0.0.0",
-    "ruff>=0.11.10",
-]
+dependencies = []
 
 # Set curent project as a package, with src/ folder.
 [tool.uv]
@@ -31,8 +27,4 @@ convention = "numpy"
 
 # Set ruff as only a local deps for development.
 [dependency-groups]
-dev = [
-    "ruff>=0.11.10",
-    "pre-commit>=4.2.0",
-    "ty>=0.0.0",
-]
+dev = []


### PR DESCRIPTION
Switches ruff, ty, and pre-commit to be run via uvx, removing them as project/dev dependencies. Updates README to reflect new setup.